### PR TITLE
Remove prepublish not supported after npm v5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: 14
           registry-url: "https://registry.npmjs.org"
       - run: npm install
+      - run: npm run lint && npm run test
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ update
 
 # Dependency directory
 node_modules
+.github

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "banknote",
-  "version": "0.2.4",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "banknote",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Module for handling currency formatting.",
   "main": "index.js",
   "scripts": {
-    "prepublish": "npm run lint && npm test",
     "update-cldr-data": "node update",
     "lint": "eslint .",
     "test": "mocha test",


### PR DESCRIPTION
- Remove prepublish not supported after npm v5
- Add `.github` workflows to `.npmignore` to prevent publishing this to npm package